### PR TITLE
feat: scrollable targets table, auto-start services in web mode

### DIFF
--- a/AisToN2K/Program.cs
+++ b/AisToN2K/Program.cs
@@ -601,17 +601,24 @@ namespace AisToN2K
             }
             Console.WriteLine($"📱 Press Ctrl+C to stop...");
 
-            // Auto-start services (same as TUI/headless), respecting --no-* flags
+            // Auto-start services after Kestrel is listening, so the web UI is
+            // available immediately even if the AIS provider is slow/unreachable.
             bool noWs = args.Contains("--no-ws");
             bool noTcp = args.Contains("--no-tcp");
             bool noUdp = args.Contains("--no-udp");
 
-            if (!noTcp && _config.Network.EnableTcp)
-                await _serviceManager.StartTcpServerAsync();
-            if (!noUdp && _config.Network.EnableUdp)
-                await _serviceManager.StartUdpServerAsync();
-            if (!noWs)
-                await _serviceManager.StartWebSocketAsync();
+            lifetime.ApplicationStarted.Register(() =>
+            {
+                _ = Task.Run(async () =>
+                {
+                    if (!noTcp && _config.Network.EnableTcp)
+                        await _serviceManager.StartTcpServerAsync();
+                    if (!noUdp && _config.Network.EnableUdp)
+                        await _serviceManager.StartUdpServerAsync();
+                    if (!noWs)
+                        await _serviceManager.StartWebSocketAsync();
+                });
+            });
             
             await app.RunAsync();
         }

--- a/AisToN2K/Program.cs
+++ b/AisToN2K/Program.cs
@@ -600,6 +600,18 @@ namespace AisToN2K
                 Console.WriteLine("⚠️ External access enabled - ensure you trust the network and have set any necessary firewall rules.");
             }
             Console.WriteLine($"📱 Press Ctrl+C to stop...");
+
+            // Auto-start services (same as TUI/headless), respecting --no-* flags
+            bool noWs = args.Contains("--no-ws");
+            bool noTcp = args.Contains("--no-tcp");
+            bool noUdp = args.Contains("--no-udp");
+
+            if (!noTcp && _config.Network.EnableTcp)
+                await _serviceManager.StartTcpServerAsync();
+            if (!noUdp && _config.Network.EnableUdp)
+                await _serviceManager.StartUdpServerAsync();
+            if (!noWs)
+                await _serviceManager.StartWebSocketAsync();
             
             await app.RunAsync();
         }

--- a/AisToN2K/wwwroot/index.html
+++ b/AisToN2K/wwwroot/index.html
@@ -213,7 +213,7 @@
         <!-- Targets (vessels heard) -->
         <div class="card">
             <h2>🚢 Vessels Heard <span id="targetsCount" style="font-size:13px; color:#666; font-weight:normal;"></span></h2>
-            <div style="overflow-x: auto; max-height: 740px; overflow-y: auto;">
+            <div style="overflow-x: auto; max-height: min(740px, 60vh); overflow-y: auto;">
                 <table class="targets-table" id="targetsTable">
                     <thead>
                         <tr>

--- a/AisToN2K/wwwroot/index.html
+++ b/AisToN2K/wwwroot/index.html
@@ -67,7 +67,7 @@
         .tracking-stat .lbl { font-size: 11px; color: #666; text-transform: uppercase; }
         /* Targets table */
         .targets-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-        .targets-table th { background: #1e3c72; color: white; padding: 10px 12px; text-align: left; cursor: pointer; user-select: none; }
+        .targets-table th { background: #1e3c72; color: white; padding: 10px 12px; text-align: left; cursor: pointer; user-select: none; position: sticky; top: 0; z-index: 1; }
         .targets-table th:hover { background: #2a5298; }
         .targets-table td { padding: 8px 12px; border-bottom: 1px solid #eee; }
         .targets-table tr:hover { background: #f0f7ff; }
@@ -213,7 +213,7 @@
         <!-- Targets (vessels heard) -->
         <div class="card">
             <h2>🚢 Vessels Heard <span id="targetsCount" style="font-size:13px; color:#666; font-weight:normal;"></span></h2>
-            <div style="overflow-x: auto;">
+            <div style="overflow-x: auto; max-height: 740px; overflow-y: auto;">
                 <table class="targets-table" id="targetsTable">
                     <thead>
                         <tr>


### PR DESCRIPTION
## Summary

Two improvements to the web UI mode:

### 1. Scrollable targets table
The vessels heard (targets) table was growing unbounded, consuming excessive vertical space. Now capped at ~20 visible rows with vertical scrolling.

### 2. Auto-start services in web mode
WebSocket, TCP, and UDP services now start automatically when launching with --web, matching TUI/headless behavior. Services start after Kestrel is listening so the web UI is available immediately even if the AIS provider is slow.

## Changes

- AisToN2K/wwwroot/index.html - Add max-height: min(740px, 60vh) + overflow-y: auto to targets wrapper, sticky thead
- AisToN2K/Program.cs - Auto-start services via ApplicationStarted callback, respecting --no-ws/--no-tcp/--no-udp flags